### PR TITLE
feat: general template (copy project and replace patterns)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,10 +26,8 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build -c ${{ matrix.configuration }} --no-restore
-    - name: Setup environment variables
-      run: export SCAFFOLD_TEMPLATES=$(pwd)/templates
     - name: Test
-      run: dotnet test -c ${{ matrix.configuration }} --no-build --verbosity normal
+      run: SCAFFOLD_TEMPLATES=$(pwd)/templates dotnet test -c ${{ matrix.configuration }} --no-build --verbosity normal
 
   publish:
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,6 +26,8 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build -c ${{ matrix.configuration }} --no-restore
+    - name: Setup environment variables
+      run: export SCAFFOLD_TEMPLATES=$(pwd)/templates
     - name: Test
       run: dotnet test -c ${{ matrix.configuration }} --no-build --verbosity normal
 
@@ -60,6 +62,17 @@ jobs:
         path: |
           scaffold-${{ matrix.runtime }}
           scaffold-${{ matrix.runtime }}.exe
+    - name: Upload templates
+      uses: actions/upload-artifact@v2.2.3
+      with:
+        name: templates
+        path: templates/
+    - name: Download zipped templates
+      uses: actions/download-artifact@v2.0.9
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        name: templates
+        path: templates.zip
     - name: Create a release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
@@ -67,5 +80,6 @@ jobs:
         files: |
           scaffold-${{ matrix.runtime }}
           scaffold-${{ matrix.runtime }}.exe
+          templates.zip
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/Scaffold.sln
+++ b/Scaffold.sln
@@ -1,60 +1,51 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31229.75
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "files", "files", "{357B2FDE-90DA-45AB-88B0-E77DFE5E8482}"
-ProjectSection(SolutionItems) = preProject
-	README.md = README.md
-	.gitignore = .gitignore
-	LICENSE = LICENSE
-	CONTRIBUTING.md = CONTRIBUTING.md
-	CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
+		CONTRIBUTING.md = CONTRIBUTING.md
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{F33BC466-255B-4B9C-B235-7E677BEE0BAA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scaffold", "src\Scaffold\Scaffold.csproj", "{D2FCDAA7-0C07-499D-A0E2-F05BF22C76F7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scaffold", "src\Scaffold\Scaffold.csproj", "{D2FCDAA7-0C07-499D-A0E2-F05BF22C76F7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scaffold.Tests", "tests\Scaffold.Tests\Scaffold.Tests.csproj", "{55909D57-D8E3-4A6A-9A8B-6F0A2BAED7C3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scaffold.Tests", "tests\Scaffold.Tests\Scaffold.Tests.csproj", "{55909D57-D8E3-4A6A-9A8B-6F0A2BAED7C3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Loader.FileSystem.Tests", "tests\Loader.FileSystem.Tests\Loader.FileSystem.Tests.csproj", "{7AA0D321-C338-47D0-ACA3-D988A78A1ADE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Loader.FileSystem.Tests", "tests\Loader.FileSystem.Tests\Loader.FileSystem.Tests.csproj", "{7AA0D321-C338-47D0-ACA3-D988A78A1ADE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Templater.Regex.Tests", "tests\Templater.Regex.Tests\Templater.Regex.Tests.csproj", "{705C116A-1305-4788-A524-3C679833118D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Templater.Regex.Tests", "tests\Templater.Regex.Tests\Templater.Regex.Tests.csproj", "{705C116A-1305-4788-A524-3C679833118D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Generator.Local.Tests", "tests\Generator.Local.Tests\Generator.Local.Tests.csproj", "{3CF67A99-5451-4CF4-8EEC-F1AE6CF0EAA3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Generator.Local.Tests", "tests\Generator.Local.Tests\Generator.Local.Tests.csproj", "{3CF67A99-5451-4CF4-8EEC-F1AE6CF0EAA3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "src\Domain\Domain.csproj", "{AE7A9B15-FFAC-481E-8A32-186D0AB5A3F4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Domain", "src\Domain\Domain.csproj", "{AE7A9B15-FFAC-481E-8A32-186D0AB5A3F4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Generator.Local", "src\Generator.Local\Generator.Local.csproj", "{1004A6BF-5F62-472B-A62D-7233E3076782}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Generator.Local", "src\Generator.Local\Generator.Local.csproj", "{1004A6BF-5F62-472B-A62D-7233E3076782}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Loader.FileSystem", "src\Loader.FileSystem\Loader.FileSystem.csproj", "{BE5559AC-9564-42FC-8801-BE96D6B73F77}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Loader.FileSystem", "src\Loader.FileSystem\Loader.FileSystem.csproj", "{BE5559AC-9564-42FC-8801-BE96D6B73F77}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Templater.Regex", "src\Templater.Regex\Templater.Regex.csproj", "{466E8CC8-BC85-4610-A3C5-67BDED4882DA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Templater.Regex", "src\Templater.Regex\Templater.Regex.csproj", "{466E8CC8-BC85-4610-A3C5-67BDED4882DA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Logic", "src\Logic\Logic.csproj", "{049ECB94-279B-4B4F-BD36-1941BD995342}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Logic", "src\Logic\Logic.csproj", "{049ECB94-279B-4B4F-BD36-1941BD995342}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{0832002A-0042-45F1-BC3A-2D93D714DC0D}"
-ProjectSection(SolutionItems) = preProject
-	.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
-	.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
+		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{D2FCDAA7-0C07-499D-A0E2-F05BF22C76F7} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
-		{55909D57-D8E3-4A6A-9A8B-6F0A2BAED7C3} = {F33BC466-255B-4B9C-B235-7E677BEE0BAA}
-		{7AA0D321-C338-47D0-ACA3-D988A78A1ADE} = {F33BC466-255B-4B9C-B235-7E677BEE0BAA}
-		{705C116A-1305-4788-A524-3C679833118D} = {F33BC466-255B-4B9C-B235-7E677BEE0BAA}
-		{3CF67A99-5451-4CF4-8EEC-F1AE6CF0EAA3} = {F33BC466-255B-4B9C-B235-7E677BEE0BAA}
-		{AE7A9B15-FFAC-481E-8A32-186D0AB5A3F4} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
-		{1004A6BF-5F62-472B-A62D-7233E3076782} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
-		{BE5559AC-9564-42FC-8801-BE96D6B73F77} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
-		{466E8CC8-BC85-4610-A3C5-67BDED4882DA} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
-		{049ECB94-279B-4B4F-BD36-1941BD995342} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D2FCDAA7-0C07-499D-A0E2-F05BF22C76F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -97,5 +88,23 @@ Global
 		{049ECB94-279B-4B4F-BD36-1941BD995342}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{049ECB94-279B-4B4F-BD36-1941BD995342}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{049ECB94-279B-4B4F-BD36-1941BD995342}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D2FCDAA7-0C07-499D-A0E2-F05BF22C76F7} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
+		{55909D57-D8E3-4A6A-9A8B-6F0A2BAED7C3} = {F33BC466-255B-4B9C-B235-7E677BEE0BAA}
+		{7AA0D321-C338-47D0-ACA3-D988A78A1ADE} = {F33BC466-255B-4B9C-B235-7E677BEE0BAA}
+		{705C116A-1305-4788-A524-3C679833118D} = {F33BC466-255B-4B9C-B235-7E677BEE0BAA}
+		{3CF67A99-5451-4CF4-8EEC-F1AE6CF0EAA3} = {F33BC466-255B-4B9C-B235-7E677BEE0BAA}
+		{AE7A9B15-FFAC-481E-8A32-186D0AB5A3F4} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
+		{1004A6BF-5F62-472B-A62D-7233E3076782} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
+		{BE5559AC-9564-42FC-8801-BE96D6B73F77} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
+		{466E8CC8-BC85-4610-A3C5-67BDED4882DA} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
+		{049ECB94-279B-4B4F-BD36-1941BD995342} = {8CCB995A-2F68-47DF-8C6E-CE9DCB10803A}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {49C4A777-E93A-46DB-8DE0-602546BEC4E4}
 	EndGlobalSection
 EndGlobal

--- a/src/Domain/Context.cs
+++ b/src/Domain/Context.cs
@@ -1,5 +1,8 @@
 namespace Model
 {
+    /// <summary>
+    /// Contex in which creatin project.
+    /// </summary>
     public class Context
     {
         public string ProjectName { get; init; }

--- a/src/Domain/Context.cs
+++ b/src/Domain/Context.cs
@@ -1,7 +1,7 @@
 namespace Model
 {
     /// <summary>
-    /// Contex in which creatin project.
+    /// Contex in which creating project.
     /// </summary>
     public class Context
     {

--- a/src/Domain/File.cs
+++ b/src/Domain/File.cs
@@ -1,7 +1,11 @@
+using System.IO;
+
 namespace Model
 {
     public class File
     {
+        public FileInfo Info { get; init; }
+
         public bool ContainsTemplates()
         {
             throw new System.NotImplementedException();

--- a/src/Domain/File.cs
+++ b/src/Domain/File.cs
@@ -1,14 +1,23 @@
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace Model
 {
+    /// <summary>
+    /// Custom File, that include standart FileInfo. Method ContainsTemplates need for testing
+    /// </summary>
     public class File
     {
         public FileInfo Info { get; init; }
 
+        /// <summary>
+        /// Check if there's any unreplaced template with format {{ .Something }}
+        /// </summary>
+        /// <returns></returns>
         public bool ContainsTemplates()
         {
-            throw new System.NotImplementedException();
+            var text = System.IO.File.ReadAllText(Info.FullName);
+            return Regex.IsMatch(text, @"{{ \..* }}");
         }
     }
 }

--- a/src/Domain/Project.cs
+++ b/src/Domain/Project.cs
@@ -2,6 +2,9 @@ using System.Collections.Generic;
 
 namespace Model
 {
+    /// <summary>
+    /// Information about created project
+    /// </summary>
     public class Project
     {
         public IEnumerable<File> CreatedFiles { get; init; }

--- a/src/Domain/Template.cs
+++ b/src/Domain/Template.cs
@@ -2,10 +2,12 @@ using System.Collections.Generic;
 
 namespace Model
 {
-    public class Template
+    /// <summary>
+    /// Template contains all info about template, files and plugins used by it
+    /// </summary>
+    public class Template : TemplateInfo
     {
-        public string Language { get; init; }
-        public string TemplateName { get; init; }
+        // All files of template
         public IEnumerable<File> Files { get; init; }
         public IEnumerable<Plugin> Plugins { get; init; }
     }

--- a/src/Domain/Template.cs
+++ b/src/Domain/Template.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 
 namespace Model
 {
@@ -7,6 +8,8 @@ namespace Model
     /// </summary>
     public class Template : TemplateInfo
     {
+        public DirectoryInfo RootDirectory { get; init; }
+
         // All files of template
         public IEnumerable<File> Files { get; init; }
         public IEnumerable<Plugin> Plugins { get; init; }

--- a/src/Domain/TemplateInfo.cs
+++ b/src/Domain/TemplateInfo.cs
@@ -1,0 +1,11 @@
+﻿namespace Model
+{
+    /// <summary>
+    /// TemplateInfo contains template name and language
+    /// </summary>
+    public class TemplateInfo
+    {
+        public string Language { get; init; }
+        public string TemplateName { get; init; }
+    }
+}

--- a/src/Domain/TemplateInfo.cs
+++ b/src/Domain/TemplateInfo.cs
@@ -6,6 +6,6 @@
     public class TemplateInfo
     {
         public string Language { get; init; }
-        public string TemplateName { get; init; }
+        public string Name { get; init; }
     }
 }

--- a/src/Generator.Local/LocalGenerator.cs
+++ b/src/Generator.Local/LocalGenerator.cs
@@ -1,19 +1,42 @@
 using System;
 using Business;
 using Model;
+using System.IO;
+using System.Collections.Generic;
 
 namespace Generator.Local
 {
     public class LocalGenerator : IGenerator
     {
-        public LocalGenerator(Template template)
+        public Project Generate(string pathToProject, Template template)
         {
-            throw new NotImplementedException();
-        }
+            var createdFiles = new List<Model.File>();
+            foreach (var file in template.Files)
+            {
+                if (file.Info.Name == "template.yml")
+                {
+                    continue;
+                }
 
-        public Project Generate(string pathToProject)
-        {
-            throw new NotImplementedException();
+                // delete root directory from file name
+                var tempFilePath = file.Info.FullName.Replace($"{template.RootDirectory.FullName}", "");
+
+                var newFileName = $"{pathToProject}{tempFilePath}";
+                FileInfo fi = new FileInfo(newFileName);
+
+                // if there is no directory
+                fi.Directory.Create();
+
+                // copy file
+                file.Info.CopyTo(newFileName);
+
+                createdFiles.Add(new Model.File {Info = fi});
+            }
+
+            return new Project
+            {
+                CreatedFiles = createdFiles
+            };
         }
     }
 }

--- a/src/Loader.FileSystem/FileSystemLoader.cs
+++ b/src/Loader.FileSystem/FileSystemLoader.cs
@@ -51,6 +51,7 @@ namespace Loader.FileSystem
                 Name = template,
                 Files = Directory.GetFiles(dirPath, "*.*", SearchOption.AllDirectories)
                     .Select(x => new Model.File() { Info = new FileInfo(x) }),
+                RootDirectory = new DirectoryInfo(dirPath),
             };
         }
     }

--- a/src/Loader.FileSystem/FileSystemLoader.cs
+++ b/src/Loader.FileSystem/FileSystemLoader.cs
@@ -1,13 +1,39 @@
 using Business;
 using Model;
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Collections;
 
 namespace Loader.FileSystem
 {
     public class FileSystemLoader : ILoader
     {
+        private readonly string _pathToTemplates;
+
         public FileSystemLoader(string pathToTemplates)
         {
-            throw new System.NotImplementedException();
+            _pathToTemplates = pathToTemplates;
+        }
+
+        public IEnumerable<TemplateInfo> GetAllLanguagesAndTemplateNames()
+        {
+            var di = new DirectoryInfo(_pathToTemplates);
+            if (!di.Exists)
+            {
+                return null;
+            }
+
+            var templateInfos = new List<TemplateInfo>();
+            foreach (var lang in di.GetDirectories())
+            {
+                foreach (var template in lang.GetDirectories())
+                {
+                    templateInfos.Add(new TemplateInfo {Language = lang.Name, TemplateName = template.Name});
+                }
+            }
+
+            return templateInfos;
         }
 
         public Template Load(string language, string template)

--- a/src/Loader.FileSystem/FileSystemLoader.cs
+++ b/src/Loader.FileSystem/FileSystemLoader.cs
@@ -29,7 +29,7 @@ namespace Loader.FileSystem
             {
                 foreach (var template in lang.GetDirectories())
                 {
-                    templateInfos.Add(new TemplateInfo {Language = lang.Name, TemplateName = template.Name});
+                    templateInfos.Add(new TemplateInfo {Language = lang.Name, Name = template.Name});
                 }
             }
 

--- a/src/Loader.FileSystem/FileSystemLoader.cs
+++ b/src/Loader.FileSystem/FileSystemLoader.cs
@@ -1,6 +1,7 @@
 using Business;
 using Model;
 using System;
+using System.Linq;
 using System.IO;
 using System.Collections.Generic;
 using System.Collections;
@@ -21,7 +22,7 @@ namespace Loader.FileSystem
             var di = new DirectoryInfo(_pathToTemplates);
             if (!di.Exists)
             {
-                return null;
+                throw new System.Exception($"{_pathToTemplates} is not exists!");
             }
 
             var templateInfos = new List<TemplateInfo>();
@@ -29,7 +30,7 @@ namespace Loader.FileSystem
             {
                 foreach (var template in lang.GetDirectories())
                 {
-                    templateInfos.Add(new TemplateInfo {Language = lang.Name, Name = template.Name});
+                    templateInfos.Add(new TemplateInfo { Language = lang.Name, Name = template.Name });
                 }
             }
 
@@ -38,7 +39,19 @@ namespace Loader.FileSystem
 
         public Template Load(string language, string template)
         {
-            throw new System.NotImplementedException();
+            var dirPath = $"{_pathToTemplates}/{language}/{template}";
+            if (!new DirectoryInfo(dirPath).Exists)
+            {
+                throw new System.Exception($"{dirPath} is not exists!");
+            }
+
+            return new Template()
+            {
+                Language = language,
+                Name = template,
+                Files = Directory.GetFiles(dirPath, "*.*", SearchOption.AllDirectories)
+                    .Select(x => new Model.File() { Info = new FileInfo(x) }),
+            };
         }
     }
 }

--- a/src/Logic/IGenerator.cs
+++ b/src/Logic/IGenerator.cs
@@ -4,6 +4,6 @@ namespace Business
 {
     public interface IGenerator
     {
-        Project Generate(string pathToProject);
+        Project Generate(string pathToProject, Template template);
     }
 }

--- a/src/Logic/ILoader.cs
+++ b/src/Logic/ILoader.cs
@@ -1,9 +1,22 @@
 using Model;
+using System.Collections.Generic;
 
 namespace Business
 {
     public interface ILoader
     {
+        /// <summary>
+        /// Loading files for template
+        /// </summary>
+        /// <param name="language">Programming language name</param>
+        /// <param name="template">Template name</param>
+        /// <returns></returns>
         Template Load(string language, string template);
+
+        /// <summary>
+        /// Get all available pairs of language and template
+        /// </summary>
+        /// <returns></returns>
+        IEnumerable<TemplateInfo> GetAllLanguagesAndTemplateNames();
     }
 }

--- a/src/Logic/ITemplater.cs
+++ b/src/Logic/ITemplater.cs
@@ -2,8 +2,17 @@ using Model;
 
 namespace Business
 {
+    /// <summary>
+    /// Templater replaces templates in files
+    /// </summary>
     public interface ITemplater
     {
+        /// <summary>
+        /// Replace templates which are specified in ctx in the project
+        /// </summary>
+        /// <param name="ctx">Context in which replace happend</param>
+        /// <param name="project">The project that is being replaced</param>
+        /// <returns></returns>
         Project Substitute(Context ctx, Project project);
     }
 }

--- a/src/Logic/ITemplater.cs
+++ b/src/Logic/ITemplater.cs
@@ -4,6 +4,6 @@ namespace Business
 {
     public interface ITemplater
     {
-        Project Substitute(Context ctx);
+        Project Substitute(Context ctx, Project project);
     }
 }

--- a/src/Scaffold/Program.cs
+++ b/src/Scaffold/Program.cs
@@ -45,18 +45,18 @@ namespace Scaffold
 
             var createArgument = new Argument<string>("template-name", "The template used to create the project when executing the command");
             createArgument.AddValidator(cr =>
-                    {
-                        var loader = _serviceProvider.GetRequiredService<ILoader>();
-                        var templateInfos = loader.GetAllLanguagesAndTemplateNames().ToList();
+            {
+                var loader = _serviceProvider.GetRequiredService<ILoader>();
+                var templateInfos = loader.GetAllLanguagesAndTemplateNames().ToList();
 
-                        // check if we have such template
-                        if (!templateInfos.Select(x => x.Name).Contains(cr.Tokens[0].Value))
-                        {
-                            return $"Sorry, but there is no '{cr.Tokens[0].Value}' template. To see entire list of templates please use 'scaffold -l'";
-                        }
+                // check if we have such template
+                if (!templateInfos.Select(x => x.Name).Contains(cr.Tokens[0].Value))
+                {
+                    return $"Sorry, but there is no '{cr.Tokens[0].Value}' template. To see entire list of templates please use 'scaffold -l'";
+                }
 
-                        return null;
-                    });
+                return null;
+            });
 
             var languageOption = new Option<string>(new[] { "-lang", "--language" }, "The language of the template to create. Depends on the template") { IsRequired = true };
             languageOption.AddValidator(cr =>
@@ -237,14 +237,17 @@ namespace Scaffold
 
             // Get required services.
             var loader = _serviceProvider.GetRequiredService<ILoader>();
-            //var generator = _serviceProvider.GetRequiredService<IGenerator>();
+            var generator = _serviceProvider.GetRequiredService<IGenerator>();
             //var templater = _serviceProvider.GetRequiredService<ITemplater>();
 
             var tl = loader.Load(language, template);
-            foreach (var item in tl.Files)
-            {
-                Console.WriteLine(item.Info.FullName);
-            }
+
+            //foreach (var item in tl.Files)
+            //{
+            //    Console.WriteLine(item.Info.FullName);
+            //}
+
+            generator.Generate(Environment.CurrentDirectory, tl);
 
             //var template = loader.Load(language, )
         }

--- a/src/Scaffold/Program.cs
+++ b/src/Scaffold/Program.cs
@@ -24,14 +24,15 @@ namespace Scaffold
             //args = new[] { "create", "hello-boy", "--git" };
 
             // Check if there folder 'templates'
-            if (!new DirectoryInfo("templates").Exists)
+            var pathToTemplates = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates";
+            if (!new DirectoryInfo(pathToTemplates).Exists)
             {
-                Console.WriteLine("Directory 'templates' not found! Please put it in the same folder as Scaffold.exe");
+                Console.WriteLine($"Directory '{$"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates"}' not found!");
                 return 0;
             }
 
             // Add services.
-            _services.AddSingleton<ILoader, FileSystemLoader>(x => new FileSystemLoader("templates"));
+            _services.AddSingleton<ILoader, FileSystemLoader>(x => new FileSystemLoader(pathToTemplates));
             _services.AddSingleton<IGenerator, LocalGenerator>();
             _services.AddSingleton<ITemplater, RegexTemplater>();
 

--- a/src/Scaffold/Program.cs
+++ b/src/Scaffold/Program.cs
@@ -240,10 +240,10 @@ namespace Scaffold
             //var templater = _serviceProvider.GetRequiredService<ITemplater>();
 
             var tl = loader.Load(language, template);
-            //foreach (var item in tl.Files)
-            //{
-            //    Console.WriteLine(item.)
-            //}
+            foreach (var item in tl.Files)
+            {
+                Console.WriteLine(item.Info.FullName);
+            }
 
             //var template = loader.Load(language, )
         }

--- a/src/Scaffold/Program.cs
+++ b/src/Scaffold/Program.cs
@@ -5,28 +5,35 @@ using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Business;
+using Generator.Local;
+using Loader.FileSystem;
+using Microsoft.Extensions.DependencyInjection;
 using Model;
+using Templater.Regex;
 
 namespace Scaffold
 {
     static class Program
     {
-        static List<Template> templates = new List<Template>() 
-        { 
+        static List<Template> templates = new List<Template>()
+        {
             new Template() { TemplateName = "tl1", Language="c#" },
             new Template() { TemplateName = "tl2", Language="go" },
             new Template() { TemplateName = "tl3", Language="go" },
             new Template() { TemplateName = "tl4", Language="c#" },
         };
+        private static readonly ServiceCollection _services = new ServiceCollection();
+        private static ServiceProvider _serviceProvider;
 
         private static async Task<int> Main(string[] args)
         {
-            // var services = new ServiceCollection();
-
             // Add services.
-            // services.AddScoped<InterfaceType, RealType>();
+            _services.AddSingleton<ILoader, FileSystemLoader>(x => new FileSystemLoader("C:\\templates"));
+            _services.AddSingleton<IGenerator, LocalGenerator>();
+            _services.AddSingleton<ITemplater, RegexTemplater>();
 
-            // await using var serviceProvider = services.BuildServiceProvider();
+            _serviceProvider = _services.BuildServiceProvider();
 
             // Get required services.
             // var v = serviceProvider.GetRequiredService<InterfaceType>();
@@ -35,15 +42,6 @@ namespace Scaffold
             {
                 new Option<bool>(new[] {"-l", "--list"}, "Displays the entire list of templates"),
             };
-
-            //var languageOption = new Option<string>(new[] { "-lang", "--language" }, "The language of the template to create. Depends on the template") { IsRequired = true };
-            //languageOption.FromAmong("c#", "C#", "csharp", "go", "GO");
-
-            //var outputOption = new Option<DirectoryInfo>(new[] { "-o", "--output" }, "Sets the location where the template will be created");
-            //outputOption.ExistingOnly();
-
-            //var templateArgument = new Argument<string>("template", "The template used to create the project when executing the command");
-            //templateArgument.FromAmong(templates.Select(x => x.Name).ToArray());
 
             var createCommand = new Command("create", "Create a project using the specified template")
             {
@@ -99,10 +97,12 @@ namespace Scaffold
         /// </summary>
         private static void ShowListTemplates()
         {
+            var loader = _serviceProvider.GetRequiredService<ILoader>();
+            var templateInfos = loader.GetAllLanguagesAndTemplateNames().ToList();
             Console.WriteLine("n    Name   Languages");
-            for (int i = 0; i < templates.Count(); i++)
+            for (int i = 0; i < templateInfos.Count(); i++)
             {
-                Console.WriteLine($"{i+1}    {templates[i].TemplateName}    {templates[i].Language}");
+                Console.WriteLine($"{i + 1}    {templateInfos[i].TemplateName}    {templateInfos[i].Language}");
             }
         }
 
@@ -136,74 +136,85 @@ namespace Scaffold
 
             if (output != null)
             {
-                Console.WriteLine($"Output directory set to \"{output}\".");
+                Console.WriteLine($"TODO Output directory set to \"{output}\".");
             }
 
             if (!string.IsNullOrEmpty(name))
             {
-                Console.WriteLine($"The name of the output data set to {name}.");
+                Console.WriteLine($"TODO The name of the output data set to {name}.");
             }
 
             if (!string.IsNullOrEmpty(version))
             {
-                Console.WriteLine($"The SDK version set to {version}.");
+                Console.WriteLine($"TODO The SDK version set to {version}.");
             }
 
             if (git)
             {
-                Console.WriteLine($"Added git support.");
+                Console.WriteLine($"TODO Added git support.");
             }
 
             if (docker)
             {
-                Console.WriteLine($"Added Dockerfile support.");
+                Console.WriteLine($"TODO Added Dockerfile support.");
             }
 
             if (kubernetes)
             {
-                Console.WriteLine($"Added Kubernetes support.");
+                Console.WriteLine($"TODO Added Kubernetes support.");
             }
 
             if (gitignore)
             {
-                Console.WriteLine($"Added .gitignore file.");
+                Console.WriteLine($"TODO Added .gitignore file.");
             }
 
             if (dockerignore)
             {
-                Console.WriteLine($"Added .dockerignore file.");
+                Console.WriteLine($"TODO Added .dockerignore file.");
             }
 
             if (readme)
             {
-                Console.WriteLine($"Added README.md file.");
+                Console.WriteLine($"TODO Added README.md file.");
             }
 
             if (contributing)
             {
-                Console.WriteLine($"Added CONTRIBUTING.md file.");
+                Console.WriteLine($"TODO Added CONTRIBUTING.md file.");
             }
 
             if (license)
             {
-                Console.WriteLine($"Added LICENSE file.");
+                Console.WriteLine($"TODO Added LICENSE file.");
             }
 
             if (codeofproduct)
             {
-                Console.WriteLine($"Added CODE_OF_PRODUCT.md file.");
+                Console.WriteLine($"TODO Added CODE_OF_PRODUCT.md file.");
             }
 
             if (githubworkflows)
             {
-                Console.WriteLine($"Added files for GitHub Workflows.");
+                Console.WriteLine($"TODO Added files for GitHub Workflows.");
             }
 
             if (gitlabci)
             {
-                Console.WriteLine($"Added files for GitLab CI.");
+                Console.WriteLine($"TODO Added files for GitLab CI.");
             }
 
+            var loader = _serviceProvider.GetRequiredService<ILoader>();
+            // var generator = serviceProvider.GetRequiredService<>();
+            // var templater = serviceProvider.GetRequiredService<>();
+            var templateInfos = loader.GetAllLanguagesAndTemplateNames().ToList();
+            Console.WriteLine("n    Name   Languages");
+            for (int i = 0; i < templateInfos.Count(); i++)
+            {
+                Console.WriteLine($"{i + 1}    {templateInfos[i].TemplateName}    {templateInfos[i].Language}");
+            }
+
+            //var template = loader.Load(language, )
         }
     }
 }

--- a/src/Scaffold/Program.cs
+++ b/src/Scaffold/Program.cs
@@ -22,11 +22,23 @@ namespace Scaffold
 
         private static async Task<int> Main(string[] args)
         {
-            // Check if there folder 'templates'. It must be plasec in %user$/.scaffold/
-            var pathToTemplates = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates";
+            string pathToTemplates = "";
+            try
+            {
+                pathToTemplates = Environment.GetEnvironmentVariable("SCAFFOLD_TEMPLATES");
+            }
+            catch (Exception) { }
+
+            if (string.IsNullOrEmpty(pathToTemplates))
+            {
+                pathToTemplates = $"{Environment.CurrentDirectory}\\templates";
+            }
+
             if (!new DirectoryInfo(pathToTemplates).Exists)
             {
-                Console.WriteLine($"Directory '{$"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates"}' not found!");
+                Console.WriteLine($"Directory '{pathToTemplates}' not found!");
+                Console.WriteLine($"Press any key to continue...");
+                Console.ReadKey();
                 return 0;
             }
 
@@ -327,6 +339,8 @@ namespace Scaffold
 
             //if (project.Compiles()) { 
             Console.WriteLine("Project crated successfully");
+            Console.WriteLine($"Press any key to continue...");
+            Console.ReadKey();
             //}
             //else
             //{

--- a/src/Scaffold/Scaffold.csproj
+++ b/src/Scaffold/Scaffold.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -13,8 +13,10 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\Generator.Local\Generator.Local.csproj" />
       <ProjectReference Include="..\Loader.FileSystem\Loader.FileSystem.csproj" />
       <ProjectReference Include="..\Logic\Logic.csproj" />
+      <ProjectReference Include="..\Templater.Regex\Templater.Regex.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Scaffold/Scaffold.csproj
+++ b/src/Scaffold/Scaffold.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <RuntimeIdentifiers>win-x64;win-x86;win-arm;win-arm64;linux-x64;linux-arm;linux-arm64;osx-x64</RuntimeIdentifiers>
         <LangVersion>9</LangVersion>
+        <Version>0.1.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Templater.Regex/RegexTemplater.cs
+++ b/src/Templater.Regex/RegexTemplater.cs
@@ -5,12 +5,7 @@ namespace Templater.Regex
 {
     public class RegexTemplater : ITemplater
     {
-        public RegexTemplater(string pathToProject)
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public Project Substitute(Context ctx)
+        public Project Substitute(Context ctx, Project project)
         {
             throw new System.NotImplementedException();
         }

--- a/src/Templater.Regex/RegexTemplater.cs
+++ b/src/Templater.Regex/RegexTemplater.cs
@@ -1,13 +1,72 @@
 using Business;
 using Model;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Templater.Regex
 {
+    /// <summary>
+    /// Templater use regex
+    /// </summary>
     public class RegexTemplater : ITemplater
     {
         public Project Substitute(Context ctx, Project project)
         {
-            throw new System.NotImplementedException();
+            var processedFiles = new List<Model.File>();
+            if (project.ProcessedFiles != null)
+            {
+                processedFiles.AddRange(project.ProcessedFiles);
+            }
+
+            var tempCreatedFiles = project.CreatedFiles.ToList();
+            for (int i = 0; i < tempCreatedFiles.Count; i++)
+            {
+                // Replace templates in TEXT
+                var file = tempCreatedFiles[i];
+                var text = System.IO.File.ReadAllText(file.Info.FullName);
+                var processedText = ReplaceTemplates(text, ctx);
+                System.IO.File.WriteAllText(file.Info.FullName, processedText);
+
+                // Replace templates in DIRECTORY NAMES
+                var processedDirectoryName = ReplaceTemplates(file.Info.Directory.FullName, ctx);
+                if (file.Info.Directory.FullName != processedDirectoryName)
+                {
+                    System.IO.Directory.Move(file.Info.Directory.FullName, processedDirectoryName);
+                    for (int j = 0; j < tempCreatedFiles.Count; j++)
+                    {
+                        tempCreatedFiles[j] = new Model.File
+                        {
+                            Info = new FileInfo(
+                                tempCreatedFiles[j].Info.FullName.Replace(file.Info.Directory.FullName, processedDirectoryName)
+                            )
+                        };
+                    }
+                }
+
+                // Replace templates in FILE NAMES
+                var processedFileName = ReplaceTemplates(file.Info.FullName, ctx);
+                if (file.Info.FullName != processedFileName)
+                {
+                    System.IO.File.Move(Path.Combine(processedDirectoryName, file.Info.Name), processedFileName);
+                    file = new Model.File {Info = new FileInfo(processedFileName)};
+                }
+
+                processedFiles.Add(file);
+            }
+
+            return new Project
+            {
+                ProcessedFiles = processedFiles
+            };
+        }
+
+        public string ReplaceTemplates(string textWithTemplates, Context ctx)
+        {
+            var processedText = textWithTemplates.Replace($"{{{{ .{nameof(ctx.ProjectName)} }}}}", ctx.ProjectName);
+            processedText = processedText.Replace($"{{{{ .{nameof(ctx.Version)} }}}}", ctx.Version);
+            processedText = processedText.Replace($"{{{{ .{nameof(ctx.Description)} }}}}", ctx.Description);
+            return processedText;
         }
     }
 }

--- a/templates/c#/console/template.yml
+++ b/templates/c#/console/template.yml
@@ -1,0 +1,2 @@
+cheburashka \{text not need to delete\}
+{HELLO_BOY}

--- a/templates/c#/console/{{ .ProjectName }}/Program.cs
+++ b/templates/c#/console/{{ .ProjectName }}/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace {{ .ProjectName }}
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/templates/c#/console/{{ .ProjectName }}/{{ .ProjectName }}.csproj
+++ b/templates/c#/console/{{ .ProjectName }}/{{ .ProjectName }}.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>{{ .Version }}</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/templates/c#/tl2/template.yml
+++ b/templates/c#/tl2/template.yml
@@ -1,1 +1,0 @@
-bala bala bala

--- a/templates/c#/tl2/template.yml
+++ b/templates/c#/tl2/template.yml
@@ -1,0 +1,1 @@
+bala bala bala

--- a/templates/c#/webapi/{{ .ProjectName }}/Controllers/WeatherForecastController.cs
+++ b/templates/c#/webapi/{{ .ProjectName }}/Controllers/WeatherForecastController.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace {{ .ProjectName }}.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        private readonly ILogger<WeatherForecastController> _logger;
+
+        public WeatherForecastController(ILogger<WeatherForecastController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            var rng = new Random();
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = rng.Next(-20, 55),
+                Summary = Summaries[rng.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+    }
+}

--- a/templates/c#/webapi/{{ .ProjectName }}/Program.cs
+++ b/templates/c#/webapi/{{ .ProjectName }}/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace {{ .ProjectName }}
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/templates/c#/webapi/{{ .ProjectName }}/Properties/launchSettings.json
+++ b/templates/c#/webapi/{{ .ProjectName }}/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:23691",
+      "sslPort": 44367
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "___.ProjectName___": {
+      "commandName": "Project",
+      "dotnetRunMessages": "true",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/templates/c#/webapi/{{ .ProjectName }}/Startup.cs
+++ b/templates/c#/webapi/{{ .ProjectName }}/Startup.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
+
+namespace {{ .ProjectName }}
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+
+            services.AddControllers();
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "{{ .ProjectName }}", Version = "v1" });
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+                app.UseSwagger();
+                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "{{ .ProjectName }} v1"));
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/templates/c#/webapi/{{ .ProjectName }}/WeatherForecast.cs
+++ b/templates/c#/webapi/{{ .ProjectName }}/WeatherForecast.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace {{ .ProjectName }}
+{
+    public class WeatherForecast
+    {
+        public DateTime Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+        public string Summary { get; set; }
+    }
+}

--- a/templates/c#/webapi/{{ .ProjectName }}/appsettings.Development.json
+++ b/templates/c#/webapi/{{ .ProjectName }}/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/templates/c#/webapi/{{ .ProjectName }}/appsettings.json
+++ b/templates/c#/webapi/{{ .ProjectName }}/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/templates/c#/webapi/{{ .ProjectName }}/{{ .ProjectName }}.csproj
+++ b/templates/c#/webapi/{{ .ProjectName }}/{{ .ProjectName }}.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>{{ .Version }}</TargetFramework>
+    <RootNamespace>{{ .ProjectName }}</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+  </ItemGroup>
+
+</Project>

--- a/templates/go/tl1/template.yml
+++ b/templates/go/tl1/template.yml
@@ -1,0 +1,1 @@
+lets f go

--- a/tests/Generator.Local.Tests/Generator.Local.Tests.csproj
+++ b/tests/Generator.Local.Tests/Generator.Local.Tests.csproj
@@ -24,6 +24,7 @@
     <ItemGroup>
       <ProjectReference Include="..\..\src\Generator.Local\Generator.Local.csproj" />
       <ProjectReference Include="..\..\src\Domain\Domain.csproj" />
+      <ProjectReference Include="..\..\src\Loader.FileSystem\Loader.FileSystem.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/Generator.Local.Tests/LocalGeneratorTests.cs
+++ b/tests/Generator.Local.Tests/LocalGeneratorTests.cs
@@ -13,6 +13,7 @@ namespace Generator.Tests
         [Fact]
         public void GenerateProject()
         {
+            // Arrange
             var loader = new FileSystemLoader($"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates");
             var tl = loader.Load("c#", "tl1");
             var generator = new LocalGenerator();
@@ -23,8 +24,10 @@ namespace Generator.Tests
                 di.Delete(true);
             }
 
+            // Act
             var project = generator.Generate($"{Environment.CurrentDirectory}/testProject", tl);
 
+            // Assert
             Assert.NotEmpty(project.CreatedFiles);
         }
     }

--- a/tests/Generator.Local.Tests/LocalGeneratorTests.cs
+++ b/tests/Generator.Local.Tests/LocalGeneratorTests.cs
@@ -1,6 +1,9 @@
-// using System.Collections.Generic;
-// using Generator.Local;
-// using Model;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Generator.Local;
+using Loader.FileSystem;
+using Model;
 using Xunit;
 
 namespace Generator.Tests
@@ -10,17 +13,19 @@ namespace Generator.Tests
         [Fact]
         public void GenerateProject()
         {
-            // var template = new Template
-            // {
-            //     Language = "csharp",
-            //     Name = "webapi",
-            //     Files = new List<File>(),
-            //     Plugins = new List<Plugin>()
-            // };
-            // var generator = new LocalGenerator(template);
-            // var project = generator.Generate("path/to/project");
-            //
-            // Assert.NotEmpty(project.CreatedFiles);
+            var loader = new FileSystemLoader($"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates");
+            var tl = loader.Load("c#", "tl1");
+            var generator = new LocalGenerator();
+
+            var di = new DirectoryInfo($"{Environment.CurrentDirectory}/testProject");
+            if (di.Exists)
+            {
+                di.Delete(true);
+            }
+
+            var project = generator.Generate($"{Environment.CurrentDirectory}/testProject", tl);
+
+            Assert.NotEmpty(project.CreatedFiles);
         }
     }
 }

--- a/tests/Generator.Local.Tests/LocalGeneratorTests.cs
+++ b/tests/Generator.Local.Tests/LocalGeneratorTests.cs
@@ -14,8 +14,8 @@ namespace Generator.Tests
         public void GenerateProject()
         {
             // Arrange
-            var loader = new FileSystemLoader($"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates");
-            var tl = loader.Load("c#", "tl1");
+            var loader = new FileSystemLoader(Environment.GetEnvironmentVariable("SCAFFOLD_TEMPLATES"));
+            var tl = loader.Load("c#", "console");
             var generator = new LocalGenerator();
 
             var di = new DirectoryInfo($"{Environment.CurrentDirectory}/testProject");

--- a/tests/Loader.FileSystem.Tests/FileSystemLoaderTests.cs
+++ b/tests/Loader.FileSystem.Tests/FileSystemLoaderTests.cs
@@ -9,15 +9,19 @@ namespace Loader.Tests
         [Fact]
         public void LoadTemplate()
         {
+            // Arrange
             var loader = new FileSystemLoader($"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates");
+            
+            // Act
             var template = loader.Load("c#", "tl1");
-
+            
+            // Assert
             Assert.NotNull(template);
             Assert.Equal("c#", template.Language);
             Assert.Equal("tl1", template.Name);
             Assert.NotEmpty(template.Files);
 
-            // in curent state we not use plugins
+            // in current state we not use plugins
             //Assert.NotEmpty(template.Plugins);
         }
     }

--- a/tests/Loader.FileSystem.Tests/FileSystemLoaderTests.cs
+++ b/tests/Loader.FileSystem.Tests/FileSystemLoaderTests.cs
@@ -1,4 +1,5 @@
-// using Loader.FileSystem;
+using Loader.FileSystem;
+using System;
 using Xunit;
 
 namespace Loader.Tests
@@ -8,14 +9,16 @@ namespace Loader.Tests
         [Fact]
         public void LoadTemplate()
         {
-            // var loader = new FileSystemLoader("templates");
-            // var template = loader.Load("csharp", "webapi");
-            //
-            // Assert.NotNull(template);
-            // Assert.Equal("csharp", template.Language);
-            // Assert.Equal("webapi", template.Name);
-            // Assert.NotEmpty(template.Files);
-            // Assert.NotEmpty(template.Plugins);
+            var loader = new FileSystemLoader($"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates");
+            var template = loader.Load("c#", "tl1");
+
+            Assert.NotNull(template);
+            Assert.Equal("c#", template.Language);
+            Assert.Equal("tl1", template.Name);
+            Assert.NotEmpty(template.Files);
+
+            // in curent state we not use plugins
+            //Assert.NotEmpty(template.Plugins);
         }
     }
 }

--- a/tests/Loader.FileSystem.Tests/FileSystemLoaderTests.cs
+++ b/tests/Loader.FileSystem.Tests/FileSystemLoaderTests.cs
@@ -10,15 +10,15 @@ namespace Loader.Tests
         public void LoadTemplate()
         {
             // Arrange
-            var loader = new FileSystemLoader($"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates");
+            var loader = new FileSystemLoader(Environment.GetEnvironmentVariable("SCAFFOLD_TEMPLATES"));
 
             // Act
-            var template = loader.Load("c#", "tl1");
+            var template = loader.Load("c#", "console");
             
             // Assert
             Assert.NotNull(template);
             Assert.Equal("c#", template.Language);
-            Assert.Equal("tl1", template.Name);
+            Assert.Equal("console", template.Name);
             Assert.NotEmpty(template.Files);
 
             // in current state we not use plugins

--- a/tests/Loader.FileSystem.Tests/FileSystemLoaderTests.cs
+++ b/tests/Loader.FileSystem.Tests/FileSystemLoaderTests.cs
@@ -11,7 +11,7 @@ namespace Loader.Tests
         {
             // Arrange
             var loader = new FileSystemLoader($"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates");
-            
+
             // Act
             var template = loader.Load("c#", "tl1");
             

--- a/tests/Templater.Regex.Tests/RegexTemplaterTests.cs
+++ b/tests/Templater.Regex.Tests/RegexTemplaterTests.cs
@@ -1,5 +1,9 @@
-// using Model;
-// using Templater.Regex;
+using Generator.Local;
+using Loader.FileSystem;
+using Model;
+using System;
+using System.IO;
+using Templater.Regex;
 using Xunit;
 
 namespace Templater.Tests
@@ -9,22 +13,44 @@ namespace Templater.Tests
         [Fact]
         public void SubstituteTemplates()
         {
-            // var templater = new RegexTemplater("/path/to/project");
-            // var ctx = new Context
-            // {
-            //     ProjectName = "some-project-name",
-            //     Version = "net5.0",
-            //     Description = "New project for a new idea"
-            // };
-            // var project = templater.Substitute(ctx);
-            //
-            // Assert.NotEmpty(project.ProcessedFiles);
-            // Assert.True(project.Compiles());
-            //
-            // foreach (var file in project.ProcessedFiles)
-            // {
-            //     Assert.False(file.ContainsTemplates());
-            // }
+            //var templater = new RegexTemplater("/path/to/project");
+            //var ctx = new Context
+            //{
+            //    ProjectName = "some-project-name",
+            //    Version = "net5.0",
+            //    Description = "New project for a new idea"
+            //};
+
+            // Arrange
+            var loader = new FileSystemLoader($"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates");
+            var tl = loader.Load("c#", "tl1");
+            var generator = new LocalGenerator();
+
+            var di = new DirectoryInfo($"{Environment.CurrentDirectory}/testProject");
+            if (di.Exists)
+            {
+                di.Delete(true);
+            }
+
+            var project = generator.Generate($"{Environment.CurrentDirectory}/testProject", tl);
+
+            var templater = new RegexTemplater();
+
+            // Act
+            var templatedProject = templater.Substitute(new Context {
+                ProjectName = "testProject",
+                Description = "тестовый c# проект",
+                Version = "net5.0",
+            }, project);
+
+            // Assert
+            Assert.NotEmpty(templatedProject.ProcessedFiles);
+            //Assert.True(project.Compiles());
+
+            foreach (var file in templatedProject.ProcessedFiles)
+            {
+                Assert.False(file.ContainsTemplates());
+            }
         }
     }
 }

--- a/tests/Templater.Regex.Tests/RegexTemplaterTests.cs
+++ b/tests/Templater.Regex.Tests/RegexTemplaterTests.cs
@@ -14,8 +14,8 @@ namespace Templater.Tests
         public void SubstituteTemplates()
         {
             // Arrange
-            var loader = new FileSystemLoader($"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates");
-            var tl = loader.Load("c#", "tl1");
+            var loader = new FileSystemLoader(Environment.GetEnvironmentVariable("SCAFFOLD_TEMPLATES"));
+            var tl = loader.Load("c#", "console");
             var generator = new LocalGenerator();
 
             var di = new DirectoryInfo($"{Environment.CurrentDirectory}/testProject");
@@ -31,7 +31,7 @@ namespace Templater.Tests
             // Act
             var templatedProject = templater.Substitute(new Context {
                 ProjectName = "testProject",
-                Description = "тестовый c# проект",
+                Description = "test c# project",
                 Version = "net5.0",
             }, project);
 

--- a/tests/Templater.Regex.Tests/RegexTemplaterTests.cs
+++ b/tests/Templater.Regex.Tests/RegexTemplaterTests.cs
@@ -13,14 +13,6 @@ namespace Templater.Tests
         [Fact]
         public void SubstituteTemplates()
         {
-            //var templater = new RegexTemplater("/path/to/project");
-            //var ctx = new Context
-            //{
-            //    ProjectName = "some-project-name",
-            //    Version = "net5.0",
-            //    Description = "New project for a new idea"
-            //};
-
             // Arrange
             var loader = new FileSystemLoader($"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.scaffold\\templates");
             var tl = loader.Load("c#", "tl1");

--- a/tests/Templater.Regex.Tests/Templater.Regex.Tests.csproj
+++ b/tests/Templater.Regex.Tests/Templater.Regex.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
@@ -22,6 +22,8 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\src\Generator.Local\Generator.Local.csproj" />
+      <ProjectReference Include="..\..\src\Loader.FileSystem\Loader.FileSystem.csproj" />
       <ProjectReference Include="..\..\src\Templater.Regex\Templater.Regex.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
# Шаблон
Поместить папку [templates](https://github.com/scaffold-project/scaffold/tree/feat/general-template/templates) в папку с .exe файлом.
Иначе можно указать, создав переменную окружения SCAFFOLD_TEMPLATES и присвоив ей значение пути до папки templates.
>"C:\templates"

В шаблонах находится шаблон c# console и webapi.

# Возможное использование:
.\Scaffold.exe create console -lang c# -n "never_gonna_give_u_up" -o C:\some-thash-folder -v net5.0
.\Scaffold.exe create webapi -lang c# -n "never_gonna_let_u_down" -o C:\some-thash-folder -v net5.0

## Другое
Версия SDK теперь обязательна.
yml не работает. Поддержки плагинов нет.
C# шаблоны переименованы
Если переименовать папку c# на something то будет --lang something и всё равно создастся проект по шаблону c#.